### PR TITLE
Improved methods to obtain IP address and Interface being used

### DIFF
--- a/discover.sh
+++ b/discover.sh
@@ -26,8 +26,8 @@ trap f_terminate INT
 
 # Global variables
 distro=$(uname -n)
-interface=$(ifconfig | grep -B1 'inet addr' | egrep -v '(-|inet addr|Loopback)' | cut -d ' ' -f1)
-ip=$(ifconfig | grep 'Bcast' | awk '{print$2}' | cut -d ':' -f2)
+interface=$(ip link | awk '{print $2, $9}' | grep UP | cut -d ':' -f1)
+ip=$(ip addr | grep global | cut -d '/' -f1 | awk '{print $2}')
 long='============================================================================================================================='
 medium='====================================================================================='
 short='========================================'


### PR DESCRIPTION
Iv'e improved the method to obtain the IP address and Interface being used.

The reason for this is because I was unable to use this script when using an interface other than "eth0". This should also make it future proof and compatible with other systems not using UDEV to assign interface names (such as Arch, Fedora etc)
