### PR TITLE
Removed rogue echo at the end of the arp scan

### DIFF
--- a/discover.sh
+++ b/discover.sh
@@ -1211,7 +1211,7 @@ read choice
 case $choice in
      1) echo -n "Interface to scan: "
 	read interface
-	arp-scan -l -I $interface | egrep -v '(arp-scan|Interface|packets|Polycom|Unknown)' | awk '{print $1}' | $sip | sed '/^$/d' > $home/data/hosts-arp.txt   echo
+	arp-scan -l -I $interface | egrep -v '(arp-scan|Interface|packets|Polycom|Unknown)' | awk '{print $1}' | $sip | sed '/^$/d' > $home/data/hosts-arp.txt
      echo $medium
      echo
      echo "***Scan complete.***"


### PR DESCRIPTION
There was an echo command placed at the end of the ARP scan in the target list creation option 1. This was causing sed to fail. I removed the echo and all is well again.

-TC