### PR TITLE
discover.sh: Fix urlcrazy/egrep binary output issue

### DIFF
--- a/discover.sh
+++ b/discover.sh
@@ -351,7 +351,7 @@ case $choice in
      echo "URLCrazy                  (22/$total)"
      urlcrazy $domain > tmp
      # Clean up & Remove Blank Lines
-     egrep -v '(#|:|\?|\-|RESERVED|URLCrazy)' tmp | sed '/^$/d' > tmp2
+     egrep -av '(#|:|\?|\-|RESERVED|URLCrazy)' tmp | sed '/^$/d' > tmp2
      # Realign Columns
      sed -e 's/..,/   /g' tmp2 > tmp3
      # Convert Caps


### PR DESCRIPTION
egrep (line 354) will occasionally see the output from urlcrazy (352) as binary data. Added -a flag to egrep to force the command to process the input as text.