### PR TITLE
Improving goofile.py and adding clickable link output

### DIFF
--- a/discover.sh
+++ b/discover.sh
@@ -819,9 +819,9 @@ s/Mce/McE/g; s/Mcf/McF/g; s/Mcg/McG/g; s/Mci/McI/g; s/Mck/McK/g; s/Mcl/McL/g; s/
           echo $long >> tmp
           cat xls >> tmp
           echo >> tmp
-          cat xls >> $home/data/$domain/data/xls.htm; echo "</pre>" >> $home/data/$domain/data/xls.htm
+          cat xls >> $home/data/$domain/data/xls.htm
      else
-          echo "No data found." >> $home/data/$domain/data/xls.htm; echo "</pre>" >> $home/data/$domain/data/xls.htm
+          echo "No data found." >> $home/data/$domain/data/xls.htm
      fi
 
      if [ -e pdf ]; then
@@ -831,9 +831,9 @@ s/Mce/McE/g; s/Mcf/McF/g; s/Mcg/McG/g; s/Mci/McI/g; s/Mck/McK/g; s/Mcl/McL/g; s/
           echo $long >> tmp
           cat pdf >> tmp
           echo >> tmp
-          cat pdf >> $home/data/$domain/data/pdf.htm; echo "</pre>" >> $home/data/$domain/data/pdf.htm
+          cat pdf >> $home/data/$domain/data/pdf.htm
      else
-          echo "No data found." >> $home/data/$domain/data/pdf.htm; echo "</pre>" >> $home/data/$domain/data/pdf.htm
+          echo "No data found." >> $home/data/$domain/data/pdf.htm
      fi
 
      if [ -e ppt ]; then
@@ -843,9 +843,9 @@ s/Mce/McE/g; s/Mcf/McF/g; s/Mcg/McG/g; s/Mci/McI/g; s/Mck/McK/g; s/Mcl/McL/g; s/
           echo $long >> tmp
           cat ppt >> tmp
           echo >> tmp
-          cat ppt >> $home/data/$domain/data/ppt.htm; echo "</pre>" >> $home/data/$domain/data/ppt.htm
+          cat ppt >> $home/data/$domain/data/ppt.htm
      else
-          echo "No data found." >> $home/data/$domain/data/ppt.htm; echo "</pre>" >> $home/data/$domain/data/ppt.htm
+          echo "No data found." >> $home/data/$domain/data/ppt.htm
      fi
 
      if [ -e txt ]; then
@@ -855,9 +855,9 @@ s/Mce/McE/g; s/Mcf/McF/g; s/Mcg/McG/g; s/Mci/McI/g; s/Mck/McK/g; s/Mcl/McL/g; s/
           echo $long >> tmp
           cat txt >> tmp
           echo >> tmp
-          cat txt >> $home/data/$domain/data/txt.htm; echo "</pre>" >> $home/data/$domain/data/txt.htm
+          cat txt >> $home/data/$domain/data/txt.htm
      else
-          echo "No data found." >> $home/data/$domain/data/txt.htm; echo "</pre>" >> $home/data/$domain/data/txt.htm
+          echo "No data found." >> $home/data/$domain/data/txt.htm
      fi
 
      if [ -e doc ]; then
@@ -867,9 +867,9 @@ s/Mce/McE/g; s/Mcf/McF/g; s/Mcg/McG/g; s/Mci/McI/g; s/Mck/McK/g; s/Mcl/McL/g; s/
           echo $long >> tmp
           cat doc >> tmp
           echo >> tmp
-          cat doc >> $home/data/$domain/data/doc.htm; echo "</pre>" >> $home/data/$domain/data/doc.htm
+          cat doc >> $home/data/$domain/data/doc.htm
      else
-          echo "No data found." >> $home/data/$domain/data/doc.htm; echo "</pre>" >> $home/data/$domain/data/doc.htm
+          echo "No data found." >> $home/data/$domain/data/doc.htm
      fi
 
      cat tmp >> zreport

--- a/discover.sh
+++ b/discover.sh
@@ -321,22 +321,14 @@ case $choice in
      echo
 
      echo "goofile                   (5/$total)"
-     $discover/mods/goofile.py -d $domain -f doc > tmp
-     $discover/mods/goofile.py -d $domain -f docx >> tmp
-     $discover/mods/goofile.py -d $domain -f pdf >> tmp
-     $discover/mods/goofile.py -d $domain -f ppt >> tmp
-     $discover/mods/goofile.py -d $domain -f pptx >> tmp
-     $discover/mods/goofile.py -d $domain -f txt >> tmp
-     $discover/mods/goofile.py -d $domain -f xls >> tmp
-     $discover/mods/goofile.py -d $domain -f xlsx >> tmp
-
-     grep $domain tmp | grep -v 'Searching in' | grep -Fv '...' | sort -u > tmp2
-
-     grep '.doc' tmp2 | egrep -v '(.pdf|.ppt|.xls)' > doc
-     grep '.pdf' tmp2 > pdf
-     grep '.ppt' tmp2 > ppt
-     grep '.txt' tmp2 | grep -v 'robots.txt' > txt
-     grep '.xls' tmp2 > xls
+     python $discover/mods/goofile.py $domain doc > doc
+     python $discover/mods/goofile.py $domain docx >> doc
+     python $discover/mods/goofile.py $domain pdf > pdf
+     python $discover/mods/goofile.py $domain ppt > ppt
+     python $discover/mods/goofile.py $domain pptx >> ppt
+     python $discover/mods/goofile.py $domain txt > txt
+     python $discover/mods/goofile.py $domain xls > xls
+     python $discover/mods/goofile.py $domain xlsx >> xls
 
      # Remove all empty files
      find -type f -empty -exec rm {} +

--- a/mods/goofile.py
+++ b/mods/goofile.py
@@ -50,6 +50,7 @@ def main():
 
     if results == []:
         print("<li>No {0} files were found.</li>".format(filetype.upper()))
+        print('</ul>')
         sys.exit()
 
     while results != []:

--- a/mods/goofile.py
+++ b/mods/goofile.py
@@ -49,7 +49,7 @@ def main():
     googleDork()
 
     if results == []:
-        print("<li>No results were found.</li>")
+        print("<li>No {0} files were found.</li>".format(filetype.upper()))
         sys.exit()
 
     while results != []:

--- a/mods/goofile.py
+++ b/mods/goofile.py
@@ -21,8 +21,14 @@ def googleDork():
     global totalFiles
     global linkTemplate
 
+    headers = {
+        "Host": "www.google.com",
+        "User-agent": "Internet Explorer 6.0 ",
+        "Referrer": "www.g13net.com"
+    }
+
     url = 'https://google.com/search?num=500&q=site:{0}+filetype:{1}&num=100&start={2}'.format(domain, filetype, start)
-    page = requests.get(url)
+    page = requests.get(url, headers)
     tree = html.fromstring(page.content)
 
     results = tree.xpath('//*[@class="r"]/a/@href')

--- a/mods/goofile.py
+++ b/mods/goofile.py
@@ -9,12 +9,17 @@ domain = sys.argv[1]
 filetype = sys.argv[2]
 start = 0
 results = []
+totalFiles = 0
+
+linkTemplate = '<li><a href="{0}" target="_blank">{0}</a></li>'
 
 def googleDork():
     global domain
     global filetype
     global start
     global results
+    global totalFiles
+    global linkTemplate
 
     url = 'https://google.com/search?num=500&q=site:{0}+filetype:{1}&num=100&start={2}'.format(domain, filetype, start)
     page = requests.get(url)
@@ -22,26 +27,35 @@ def googleDork():
 
     results = tree.xpath('//*[@class="r"]/a/@href')
 
+    totalFiles += len(results)
+
     for link in results:
         m = re.match('^\/url\?q=(.*)\&sa', link)
         if m:
-            print(m.groups()[0])
+            print(linkTemplate.format(m.groups()[0]))
         else:
-            print('Could not parse the following link: ' + link)
+            print('<li>Could not parse: {0}</li>'.format(link))
 
     if results != []:
         start += 100
 
 def main():
     global results
+    global totalFiles
+    global filetype
+
+    print('<ul>')
 
     googleDork()
 
     if results == []:
-        print("No results were found.")
+        print("<li>No results were found.</li>")
         sys.exit()
 
     while results != []:
         googleDork()
+
+    print('</ul>')
+    print('<p>Total number of {0} files: {1}</p>'.format(filetype.upper(), totalFiles))
 
 main()

--- a/mods/goofile.py
+++ b/mods/goofile.py
@@ -2,7 +2,6 @@
 
 import re
 import sys
-import asyncio
 import requests
 from lxml import html
 
@@ -11,7 +10,7 @@ filetype = sys.argv[2]
 start = 0
 results = []
 
-async def googleDork():
+def googleDork():
     global domain
     global filetype
     global start
@@ -33,16 +32,16 @@ async def googleDork():
     if results != []:
         start += 100
 
-async def main():
+def main():
     global results
 
-    await googleDork()
+    googleDork()
 
     if results == []:
         print("No results were found.")
         sys.exit()
 
     while results != []:
-        await googleDork()
+        googleDork()
 
-asyncio.run(main())
+main()

--- a/report/data/doc.htm
+++ b/report/data/doc.htm
@@ -10,5 +10,4 @@
 </head>
 
 <body>
-<pre>
 

--- a/report/data/pdf.htm
+++ b/report/data/pdf.htm
@@ -10,5 +10,4 @@
 </head>
 
 <body>
-<pre>
 

--- a/report/data/ppt.htm
+++ b/report/data/ppt.htm
@@ -10,5 +10,4 @@
 </head>
 
 <body>
-<pre>
 

--- a/report/data/txt.htm
+++ b/report/data/txt.htm
@@ -10,5 +10,4 @@
 </head>
 
 <body>
-<pre>
 

--- a/report/data/xls.htm
+++ b/report/data/xls.htm
@@ -10,5 +10,4 @@
 </head>
 
 <body>
-<pre>
 


### PR DESCRIPTION
Related to issue #117

Prior to this change, `goofile.py` would return a maximum of 100 files, though the output could contain lots of duplicate filenames (due to bad parsing).

The improvements included in the PR are twofold:
* the google search result parser has been improved to recursively query beyond the first page of results (meaning we can grab _all_ results, not just the first 100)
* the output of the report (in `.htm` files) now contains clickable links, making it easy to view the files which have been found